### PR TITLE
fix: 0 metrics found error do to large scrape-config

### DIFF
--- a/ansible/metrics_playbook.yml
+++ b/ansible/metrics_playbook.yml
@@ -16,6 +16,9 @@
   hosts: localhost
   become: true
   vars:
+    prometheus_global:
+      scrape_interval: 3s
+
     prometheus_scrape_configs:
       - job_name: "node"
         static_configs:


### PR DESCRIPTION
This commit sets prometheus scrape-config to 3s so that the scrapes aren't too far apart.