### PR TITLE
chore: migrate to official equinix metal runner action

### DIFF
--- a/.github/workflows/equinix_metal_e2e.yml
+++ b/.github/workflows/equinix_metal_e2e.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: metal-runner-action
-        uses: rootfs/metal-runner-action@main
+        uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}

--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: metal-runner-action
-        uses: rootfs/metal-runner-action@main
+        uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}

--- a/.github/workflows/equinix_metal_flow_model_server_test.yml
+++ b/.github/workflows/equinix_metal_flow_model_server_test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: metal-runner-action
-        uses: rootfs/metal-runner-action@main
+        uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}

--- a/.github/workflows/equinix_metal_kepler_action_flow.yml
+++ b/.github/workflows/equinix_metal_kepler_action_flow.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: metal-runner-action
-        uses: rootfs/metal-runner-action@main
+        uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}

--- a/.github/workflows/equinix_metal_model_server_action_flow.yml
+++ b/.github/workflows/equinix_metal_model_server_action_flow.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: metal-runner-action
-        uses: rootfs/metal-runner-action@main
+        uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}

--- a/.github/workflows/equinix_metal_trainer.yml
+++ b/.github/workflows/equinix_metal_trainer.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: metal-runner-action
-        uses: rootfs/metal-runner-action@main
+        uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}


### PR DESCRIPTION
This commit updates the workflows to use the official equinix metal runner action, replacing the forked version

Key changes with equinix metal action:
- [self-hosted runners at organization level](https://github.com/equinix-labs/metal-runner-action/commit/5bd5e74e267b6f40085e407cbb39818d9eb75474) 
- [support for RHEL based OS](https://github.com/equinix-labs/metal-runner-action/commit/41be7e4c4f6c2dfe3a78eb16a7e1f945a8e95f24)