### PR TITLE
chore(rapl): Add a step to capture RAPL power domain availability

### DIFF
--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -52,6 +52,16 @@ jobs:
           sudo ansible-galaxy collection install community.libvirt
           sudo ansible-config init --disabled | sed "s/;host_key_checking=True/host_key_checking=False/g" | sed "s/;private_key_file=/private_key_file=~\/.ssh\/ansible_rsa/g" | sed 's|;roles_path={{ ANSIBLE_HOME ~ "/roles:/usr/share/ansible/roles:/etc/ansible/roles" }}|roles_path={{ ANSIBLE_HOME ~ "/roles:/usr/share/ansible/roles:/etc/ansible/roles;/root/.ansible/collections/ansible_collections/community/libvirt/roles" }}|' > /etc/ansible/ansible.cfg
 
+      - name: List available RAPL domains
+        run: |
+          for file in $(sudo find -L /sys/class/powercap/intel-rapl -name name  2>/dev/null); do cat $file;  done  | sort -n| uniq | tee -a /tmp/rapl-domain-availability.txt
+          # expected typical output if all domains are supported
+          # - core
+          # - dram
+          # - package-0
+          # - psys # relatively new power management domain, only available after Skylake
+          # - uncore
+
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -83,6 +93,7 @@ jobs:
           export KEPLER_TAG=$(ls -d /tmp/validator-* |tail -1 | sed 's/.*validator-//g')
           # copy the report to the directory
           mv /tmp/validator-${KEPLER_TAG}/report-${KEPLER_TAG}.md docs/validation/${DATE_STR}/
+          mv /tmp/rapl-domain-availability.txt docs/validation/${DATE_STR}/
           cp -r /tmp/validator-${KEPLER_TAG} docs/validation/${DATE_STR}/
           echo "| " ${DATE_STR} " | " ${KEPLER_TAG} " | [Report](validation/${DATE_STR}/report-${KEPLER_TAG}.md) | [Artifacts](validation/${DATE_STR}/validator-${KEPLER_TAG}) |" \
             >> docs/kepler-model-validation.md


### PR DESCRIPTION
  Not all processors support reading of all (`core, uncore, dram, package`) power domains. Sometimes dram is missing, other times even core is missing. This PR adds a step which tries to capture the available domains. Kepler power metrics depend on availability of these domains.