### PR TITLE
chore(metal/flow): keep reports and artifacts its own dir

### DIFF
--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -82,10 +82,9 @@ jobs:
           mkdir -p docs/validation/${DATE_STR}
           export KEPLER_TAG=$(ls -d /tmp/validator-* |tail -1 | sed 's/.*validator-//g')
           # copy the report to the directory
-          mv /tmp/validator-${KEPLER_TAG}/report-${KEPLER_TAG}.md docs/validation/${DATE_STR}/
-          mv /tmp/rapl-domain-availability.txt docs/validation/${DATE_STR}/
-          cp -r /tmp/validator-${KEPLER_TAG} docs/validation/${DATE_STR}/
-          echo "| " ${DATE_STR} " | " ${KEPLER_TAG} " | [Report](validation/${DATE_STR}/report-${KEPLER_TAG}.md) | [Artifacts](validation/${DATE_STR}/validator-${KEPLER_TAG}) |" \
+          mv /tmp/validator-${KEPLER_TAG}/ docs/validation/${DATE_STR}/
+          mv /tmp/rapl-domain-availability.txt docs/validation/${DATE_STR}/validator-${KEPLER_TAG}/
+          echo "| " ${DATE_STR} " | " ${KEPLER_TAG} " | [Report](validation/${DATE_STR}/validator-${KEPLER_TAG}/report-${KEPLER_TAG}.md) | [Artifacts](validation/${DATE_STR}/validator-${KEPLER_TAG}/artifacts) |" \
             >> docs/kepler-model-validation.md
           git config user.email "dependabot[bot]@users.noreply.github.com"
           git config user.name "dependabot[bot]"


### PR DESCRIPTION
This keeps reports and artifacts in its own dir and avoids moving report outside the `validator-<tag>` directory so that md files can embed relative to its location.

Requires: https://github.com/sustainable-computing-io/kepler/pull/1755