### PR TITLE
chore(ci): add delay before running validator

### DIFF
--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -70,6 +70,8 @@ jobs:
           ansible-playbook -i inventory.yml kepler_playbook.yml
           echo "Create ssh tunnel"
           ansible-playbook -i inventory.yml ssh_tunnel_playbook.yml
+          echo "Sleeping for 1 minute to allow Kepler to be ready before running the validation test"
+          sleep 60
           echo "Run validation test"
           ansible-playbook -vvv kepler_validator.yml
           echo "Checkout the report"


### PR DESCRIPTION
This commit adds a sleep for 1 minute before running the validator in the metal flow workflow. Since a single playbook `kepler_playbook.yml` is responsible for deploying Kepler on both BM and VM, the delay at least gives some time for Kepler to actually start up and register values on both machines
