### PR TITLE
chore(ci): update metal delete action to use sustainable-computing-io fork

### DIFF
--- a/.github/workflows/clean_equinix_runner.yml
+++ b/.github/workflows/clean_equinix_runner.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: delete runner
-        uses: rootfs/metal-delete-action@main
+        uses: sustainable-computing-io/metal-sweeper-action@main
         with:
           authToken: ${{ secrets.EQUINIX_API_TOKEN }}
           projectID: ${{ secrets.EQUINIX_PROJECT_ID }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Running Kepler on Equinix and AWS Metal instances with GitHub Actions
 - Create GitHub personal access token following [this instruction](https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-organization)
 - Create a project with the [Equinix Metal Project Action](https://github.com/equinix-labs/metal-runner-action) to create the self hosted runner
 - Run some workload
-- Delete the runner with the [Equinix Metal Delete Action](https://github.com/rootfs/metal-delete-action). Note, this action only deletes the server that serves the self hosted runner. It doesn't sweep other servers as the Equinix Metal Sweeper does.
+- Delete the runner with the [Equinix Metal Sweeper Action](https://github.com/sustainable-computing-io/metal-sweeper-action). Note, this action only deletes the server that serves the self hosted runner. It doesn't sweep other servers as the Equinix Metal Sweeper does.
 
 ## Workflows
 


### PR DESCRIPTION
This commit updates metal delete action in our CI to use the forked version maintained under sustainable-computing-io organization.