### PR TITLE
chore: enable selected collectors in node-exporter

### DIFF
--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Verify node-exporter"
           sudo systemctl status node_exporter || true
           sudo ss -tuln | grep 9100 || true
-          curl -s http://localhost:9100/metrics | grep rapl || true
+          curl -s localhost:9100/metrics | grep collector || true
           echo "Install Kepler"
           ansible-playbook -i inventory.yml kepler_playbook.yml
           echo "Create ssh tunnel"

--- a/ansible/roles/node-exporter/templates/node_exporter.service.j2
+++ b/ansible/roles/node-exporter/templates/node_exporter.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 User={{ node_exporter_user }}
-ExecStart={{ node_exporter_bin_dir }}/node_exporter --collector.rapl
+ExecStart={{ node_exporter_bin_dir }}/node_exporter --collector.disable-defaults --collector.cpu --collector.cpufreq --collector.perf --collector.meminfo --collector.rapl
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
With all default collectors enabled, node-exporter produces a lot of metrics, and prometheus can timeout scraping node-exporter.

This PR :
- Disable default collectors
- Only enable collectors `cpu, cpufreq, perf, rapl, meminfo`