### PR TITLE
feat: Add support for capturing Prometheus snapshot

### DIFF
--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -91,11 +91,20 @@ jobs:
             --report-md-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.md \
             --report-json-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.json \
             --new-val-filepath /tmp/validator-${KEPLER_TAG}/${KEPLER_TAG}.json
+
           # copy the report to the directory
           mv /tmp/validator-${KEPLER_TAG}/ docs/validation/${DATE_STR}/
           mv /tmp/rapl-domain-availability.txt docs/validation/${DATE_STR}/validator-${KEPLER_TAG}/
           echo "| " ${DATE_STR} " | " ${KEPLER_TAG} " | [Report](validation/${DATE_STR}/validator-${KEPLER_TAG}/report-${KEPLER_TAG}.md) | [Artifacts](validation/${DATE_STR}/validator-${KEPLER_TAG}/artifacts) |" \
             >> docs/kepler-model-validation.md
+
+          # Capture Prometheus TSDB Snapshot
+          mkdir -p docs/validation/${DATE_STR}/validator-${KEPLER_TAG}/prometheus-snapshot
+          snap_name=$(curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot | jq -r '.data.name')
+          tar -cvzf docs/validation/${DATE_STR}/validator-${KEPLER_TAG}/prometheus-snapshot/snapshot.tar.gz -C \
+            /var/lib/prometheus/snapshots ${snap_name}
+
+          # Push to the repo
           git config user.email "dependabot[bot]@users.noreply.github.com"
           git config user.name "dependabot[bot]"
           git add docs/*

--- a/.github/workflows/equinix_metal_model_server_action_flow.yml
+++ b/.github/workflows/equinix_metal_model_server_action_flow.yml
@@ -83,10 +83,19 @@ jobs:
             --report-md-filepath docs/daily-validations/daily-validations-model-server/daily-report.md \
             --report-json-filepath docs/daily-validations/daily-validations-model-server/daily-report.json \
             --new-val-filepath /tmp/validator-${KEPLER_TAG}/${KEPLER_TAG}.json
+
           # copy the report to the directory
           mv /tmp/validator-${KEPLER_TAG}/ docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-model-server
           echo "| " ${DATE_STR} " | " ${KEPLER_TAG}-model-server " | [Report](validation/${DATE_STR}/validator-${KEPLER_TAG}-model-server/report-${KEPLER_TAG}.md) | [Artifacts](validation/${DATE_STR}/validator-${KEPLER_TAG}-model-server/artifacts) |" \
             >> docs/kepler-model-validation.md
+
+          # Capture Prometheus TSDB Snapshot
+          mkdir -p docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-model-server/prometheus-snapshot
+          snap_name=$(curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot | jq -r '.data.name')
+          tar -cvzf docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-model-server/prometheus-snapshot/snapshot.tar.gz -C \
+            /var/lib/prometheus/snapshots ${snap_name}
+
+          # Push to the repo
           git config user.email "dependabot[bot]@users.noreply.github.com"
           git config user.name "dependabot[bot]"
           git add docs/*

--- a/ansible/metrics_playbook.yml
+++ b/ansible/metrics_playbook.yml
@@ -29,6 +29,11 @@
       - job_name: "node-exporter"
         static_configs:
           - targets: ["localhost:9100"]
+
+    prometheus_config_flags_extra:
+        web.enable-admin-api:
+        web.enable-lifecycle:
+
   roles:
     - role: prometheus.prometheus.prometheus
       vars:


### PR DESCRIPTION
This commit introduces support for capturing Prometheus Snapshot to assist with debugging and to provide a clearer understanding of Prometheus'state and the observed results

Key changes:
- Adds `prometheus_config_flags_extra` variable to prometheus role,
  enabling `web.enable-admin-api` and `web.enable-lifecycle` flags,
  which are required to take snapshot
- Updates the existing `equinix_metal_model_server_action_flow.yml`
  and `equinix_metal_flow.yml` workflows to capture the snapshot
  after the validator completes, storing it in the
  `docs/validation/<date>/validator-<kepler_tag>/prometheus-snapshot/`
  directory

Addresses: #264