### PR TITLE
chore(ci): use latest equinix metal-runner-action

### DIFF
--- a/.github/workflows/create_equinix_runner.yml
+++ b/.github/workflows/create_equinix_runner.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: metal-runner-action
-        uses: equinix-labs/metal-runner-action@v0.3.0
+        uses: equinix-labs/metal-runner-action@v0.4.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}


### PR DESCRIPTION
This commit updates the equinix metal-runner-action to use `main` which includes the latest changes to the action