### PR TITLE
feat: Add support for deploying Kepler using Compose

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -13,8 +13,15 @@ runs:
         sudo cat ~/.ssh/ansible_rsa.pub >> ~/.ssh/authorized_keys
         sudo echo "StrictHostKeyChecking no" >> ~/.ssh/config
         # install ansible
-        sudo dnf -y install ansible-core python3-pip
-        sudo dnf install -y rhel-system-roles
+        if grep -q 'Ubuntu' /etc/os-release ; then
+          sudo apt update -y
+          sudo apt install software-properties-common -y
+          sudo add-apt-repository --yes --update ppa:ansible/ansible
+          sudo apt install -y ansible python3-pip
+        else
+          sudo dnf -y install ansible-core python3-pip
+          sudo dnf install -y rhel-system-roles
+        fi
         sudo ansible-galaxy collection install prometheus.prometheus
         sudo ansible-galaxy collection install community.crypto
         sudo ansible-galaxy collection install community.libvirt

--- a/.github/workflows/create_equinix_runner.yml
+++ b/.github/workflows/create_equinix_runner.yml
@@ -2,6 +2,12 @@ name: Create Runner
 
 on:
   workflow_call:
+    inputs:
+      os_name:
+        description: "Name of the OS to be requested for the runner"
+        required: false
+        type: string
+        default: "rhel_9"
 
 jobs:
   Create-runner:
@@ -17,4 +23,4 @@ jobs:
           metal_project_id: ${{ secrets.EQUINIX_PROJECT_ID }}
           metro: "da"
           plan: "c3.small.x86"
-          os: "rhel_9"
+          os: "${{ inputs.os_name }}"

--- a/.github/workflows/validator_compose.yml
+++ b/.github/workflows/validator_compose.yml
@@ -1,0 +1,117 @@
+name: Validation with Standalone Kepler using Compose
+
+on:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+  repository-projects: write
+  packages: write
+
+jobs:
+  Create-runner:
+    name: "Create Runner"
+    uses: ./.github/workflows/create_equinix_runner.yml
+    with:
+      os_name: "ubuntu_22_04"
+    secrets: inherit
+
+  Install:
+    name: "Install"
+    needs: Create-runner
+    runs-on: self-hosted
+    continue-on-error: true
+    outputs:
+      runner-name: ${{ runner.name }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Setup Runner Action
+        uses: ./.github/actions/setup-action
+
+      - name: List available RAPL domains
+        run: |
+          for file in $(sudo find -L /sys/class/powercap/intel-rapl -name name  2>/dev/null); do cat $file;  done  | sort -n| uniq | tee -a /tmp/rapl-domain-availability.txt
+          # expected typical output if all domains are supported
+          # - core
+          # - dram
+          # - package-0
+          # - psys # relatively new power management domain, only available after Skylake
+          # - uncore
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run playbook
+        run: |
+          cd ${GITHUB_WORKSPACE}/ansible
+          echo "Run Validator Playbook"
+          ansible-playbook -vvv -i inventory.yml validator_playbook.yml
+
+          echo "Checkout the report"
+          ls /tmp
+          cat /tmp/report-*.md || true
+
+          # create a directory to store the artifacts, the directory is the current date 
+          set -x
+          export DATE_STR=$(date +%Y-%m-%d)
+          cd ${GITHUB_WORKSPACE}
+          mkdir -p docs/validation/${DATE_STR}
+          export KEPLER_TAG=$(ls -d /tmp/validator-* |tail -1 | sed 's/.*validator-//g')
+          python3 -m pip install --upgrade pip
+          pip install tabulate
+          python3 util/generate_daily_validations.py \
+            --report-md-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.md \
+            --report-json-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.json \
+            --new-val-filepath /tmp/validator-${KEPLER_TAG}/${KEPLER_TAG}.json
+
+          # copy the report to the directory
+          mv /tmp/validator-${KEPLER_TAG}/ docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-compose/
+          mv /tmp/rapl-domain-availability.txt docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-compose/
+          echo "| " ${DATE_STR} " | " ${KEPLER_TAG}-compose " | [Report](validation/${DATE_STR}/validator-${KEPLER_TAG}-compose/report-${KEPLER_TAG}.md) | [Artifacts](validation/${DATE_STR}/validator-${KEPLER_TAG}-compose/artifacts) |" \
+            >> docs/kepler-model-validation.md
+
+          # Capture Prometheus TSDB Snapshot
+          mkdir -p docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-compose/prometheus-snapshot
+          tar -cvzf docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-compose/prometheus-snapshot/snapshot.tar.gz -C \
+            /tmp/snapshot/ .
+
+          # Push to the repo
+          git config user.email "dependabot[bot]@users.noreply.github.com"
+          git config user.name "dependabot[bot]"
+          git add docs/*
+          git commit -m "Add validation report for ${DATE_STR}" -s
+          git push
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Update model validation chart
+        run: |
+          export DATE_STR=$(date +%Y-%m-%d)
+          cd ${GITHUB_WORKSPACE}
+          cd docs/analytics
+          python3 -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python3 ./kepler_analytics.py
+          # update git
+          git config user.email "dependabot[bot]@users.noreply.github.com"
+          git config user.name "dependabot[bot]"
+          cd ${GITHUB_WORKSPACE}
+          git add docs/analytics/*
+          git add docs/kepler-model-validation-chart.md
+          git commit -m "Add validation chart for ${DATE_STR}" -s
+          git push
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  Cleanup:
+    name: "Cleanup"
+    needs: [Install]
+    uses: ./.github/workflows/clean_equinix_runner.yml
+    secrets: inherit
+    with:
+      runner_name: ${{ needs.Install.outputs.runner-name }}
+

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -1,0 +1,28 @@
+Setup  Docker
+=========
+
+This role installs and configures Docker on both Metal and VM.
+
+Role Variables
+--------------
+
+- `default/main.yml`:
+  Default variables for this role.
+- `vars/main.yml`:
+  Variables defined in this file have higher precedence and are not intended to be overridden.
+  - `bm_necessary_packages`: Packages necessary for Metal.
+  - `vm_necessary_packages`: Packages necessary for VM.
+  - `ubuntu_docker_gpg_key_url`: URL of the Ubuntu Docker GPG key(Metal).
+  - `ubuntu_docker_repo_url`: URL of the Ubuntu Docker repository(Metal).
+  - `fedora_docker_repo_url`: URL of the Fedora Docker repository(VM).
+  - `docker_necessary_packages`: Packages necessary for Docker Installation.
+
+Dependencies
+------------
+
+- VM should be created using the `kvm_vm` role.
+
+License
+-------
+
+BSD

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for docker

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for docker

--- a/ansible/roles/docker/meta/main.yml
+++ b/ansible/roles/docker/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Install Docker on Metal
+  ansible.builtin.include_tasks: metal.yml
+  when: inventory_hostname == 'localhost'
+
+- name: Install Docker on VM
+  ansible.builtin.include_tasks: vm.yml
+  when: inventory_hostname == 'my-vm'
+
+- name: Validate Docker installation
+  ansible.builtin.include_tasks: validate.yml

--- a/ansible/roles/docker/tasks/metal.yml
+++ b/ansible/roles/docker/tasks/metal.yml
@@ -1,0 +1,36 @@
+---
+- name: Ensure necessary packages are installed on BM
+  ansible.builtin.package:
+    name: "{{ metal_necessary_packages }}"
+    state: present
+    update_cache: true
+
+- name: Install hatch via pip
+  ansible.builtin.pip:
+    name: hatch
+    state: latest
+
+- name: Add Docker official GPG key
+  ansible.builtin.apt_key:
+    url: "{{ metal_docker_gpg_key_url }}"
+    state: present
+
+- name: Set up Docker stable repository
+  ansible.builtin.apt_repository:
+    repo: "{{ metal_docker_repo_url }}"
+    state: present
+
+- name: Update the apt package index
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: Install Docker Engine and related packages
+  ansible.builtin.apt:
+    name: "{{ docker_necessary_packages }}"
+    state: latest
+  register: docker_install
+
+- name: Show Output
+  ansible.builtin.debug:
+    var: docker_install
+

--- a/ansible/roles/docker/tasks/validate.yml
+++ b/ansible/roles/docker/tasks/validate.yml
@@ -1,0 +1,18 @@
+- name: Ensure Docker service is running
+  ansible.builtin.service:
+    name: docker
+    state: started
+
+- name: Add user to Docker group
+  ansible.builtin.user:
+    name: "{{ ansible_user }}"
+    groups: docker
+    append: true
+
+- name: Verify Docker installation
+  ansible.builtin.command: docker --version
+  register: docker_version
+
+- name: Display Docker version
+  ansible.builtin.debug:
+    msg: "{{ docker_version.stdout }}"

--- a/ansible/roles/docker/tasks/vm.yml
+++ b/ansible/roles/docker/tasks/vm.yml
@@ -1,0 +1,18 @@
+---
+- name: Ensure necessary packages are installed on VM
+  ansible.builtin.package:
+    name: "{{ vm_necessary_packages }}"
+    state: present
+
+- name: Add Docker repository on VM
+  ansible.builtin.command: dnf config-manager --add-repo {{ vm_docker_repo_url }}
+
+- name: Install Docker on VM
+  ansible.builtin.package:
+    name: "{{ docker_necessary_packages }}"
+    state: latest
+  register: docker_install
+
+- name: Show Output
+  ansible.builtin.debug:
+    var: docker_install

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -1,0 +1,25 @@
+---
+# This file contains variables that are less likely to be overridden
+
+metal_necessary_packages:
+  - git
+  - curl
+  - ca-certificates
+  - jq
+
+vm_necessary_packages:
+  - git
+  - curl
+  - dnf-plugins-core
+  - stress-ng
+  - jq
+
+metal_docker_gpg_key_url: https://download.docker.com/linux/ubuntu/gpg
+metal_docker_repo_url: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
+vm_docker_repo_url: https://download.docker.com/linux/centos/docker-ce.repo
+docker_necessary_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-compose-plugin
+  - docker-buildx-plugin

--- a/ansible/roles/kepler_compose/README.md
+++ b/ansible/roles/kepler_compose/README.md
@@ -1,0 +1,28 @@
+Kepler Installation via Compose
+=========
+
+This role installs Kepler on both Metal and VM using Compose manifests that are available in the [Kepler repository](https://github.com/sustainable-computing-io/kepler/tree/main/manifests/compose/validation).
+
+Role Variables
+--------------
+
+- `default/main.yml`:
+  Default variables for this role.
+  - `subnet`: Subnet for the VM. Default is `192.168.122.0/24`.
+- `vars/main.yml`:
+  Variables defined in this file have higher precedence and are not intended to be overridden.
+  - `kepler_repo`: URL of the Kepler repository.
+  - `kepler_dir`: Directory where Kepler repo is cloned.
+  - `metal_compose_dir`: Directory where Metal Compose manifests are located.
+  - `vm_compose_dir`: Directory where VM Compose manifests are located.
+
+Dependencies
+------------
+
+- VM should be created using the `kvm_vm` role.
+- Docker should be installed on the VM using the `setup_docker` role.
+
+License
+-------
+
+BSD

--- a/ansible/roles/kepler_compose/defaults/main.yml
+++ b/ansible/roles/kepler_compose/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# This file contains the default values for variables used in the role
+subnet: 192.168.122.0/24

--- a/ansible/roles/kepler_compose/handlers/main.yml
+++ b/ansible/roles/kepler_compose/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for kepler_compose

--- a/ansible/roles/kepler_compose/meta/main.yml
+++ b/ansible/roles/kepler_compose/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/kepler_compose/tasks/main.yml
+++ b/ansible/roles/kepler_compose/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install Kepler on Metal
+  ansible.builtin.include_tasks: metal.yml
+  when: inventory_hostname == 'localhost'
+
+- name: Install Kepler on VM
+  ansible.builtin.include_tasks: vm.yml
+  when: inventory_hostname == 'my-vm'
+
+- name: Check if Kepler is running
+  ansible.builtin.include_tasks: validate.yml
+  when: inventory_hostname == 'localhost'

--- a/ansible/roles/kepler_compose/tasks/metal.yml
+++ b/ansible/roles/kepler_compose/tasks/metal.yml
@@ -1,0 +1,34 @@
+---
+- name: Clone Kepler and Install Kepler using Metal Compose
+  block:
+    - name: Clone kepler repo
+      ansible.builtin.git:
+        repo: "{{ kepler_repo }}"
+        dest: "{{ kepler_dir }}"
+        version: main
+
+    - name: Get latest commit details
+      ansible.builtin.shell: |
+        cd {{ kepler_dir }}
+        git log -n 1
+
+    - name: Create Docker network
+      ansible.builtin.shell: |
+        docker network create --driver=macvlan --subnet={{ subnet }} -o parent=virbr0 virt-net
+
+    - name: Start Docker compose services on BM
+      community.docker.docker_compose_v2:
+        project_src: "{{ metal_compose_dir }}"
+        build: always
+        files: compose.yaml
+        state: present
+      environment:
+        VM_IP: "{{ vm_ip }}"
+  rescue:
+    - name: Log the error
+      ansible.builtin.debug:
+        msg: "{{ ansible_failed_result }}"
+    - name: Fail the role if the Kepler installation fails
+      ansible.builtin.fail:
+        msg: "The Kepler installation failed on Metal. Please check the output above for more information."
+ 

--- a/ansible/roles/kepler_compose/tasks/validate.yml
+++ b/ansible/roles/kepler_compose/tasks/validate.yml
@@ -1,0 +1,25 @@
+---
+- name: Check if Kepler metrics are available
+  block:
+    - name: Wait for Prometheus metrics to become available
+      ansible.builtin.pause:
+        seconds: 120
+
+    - name: Check Prometheus metrics
+      ansible.builtin.shell: |
+        curl http://localhost:9090/api/v1/query -G -d query='kepler_exporter_build_info' | jq
+        curl http://localhost:9090/api/v1/query -G -d query='kepler_node_info' | jq
+      register: prometheus_metrics
+      failed_when: |
+        ('status' not in prometheus_metrics.stdout) or
+        ('success' not in prometheus_metrics.stdout) or
+        ('"result": []' in prometheus_metrics.stdout)
+
+  rescue:
+    - name: Log the error
+      ansible.builtin.debug:
+        msg: "{{ prometheus_metrics.stderr }}"
+
+    - name: Fail the role if metrics are not available
+      ansible.builtin.fail:
+        msg: "Prometheus metrics are not available. Please check the output above for more information."

--- a/ansible/roles/kepler_compose/tasks/vm.yml
+++ b/ansible/roles/kepler_compose/tasks/vm.yml
@@ -1,0 +1,28 @@
+---
+- name: Clone Kepler and Install Kepler using VM Compose
+  block:
+    - name: Clone kepler repo
+      ansible.builtin.git:
+        repo: "{{ kepler_repo }}"
+        dest: "{{ kepler_dir }}"
+        version: main
+
+    - name: Get latest commit details
+      ansible.builtin.shell: |
+        cd {{ kepler_dir }}
+        git log -n 1
+
+    - name: Start Docker compose services on VM
+      community.docker.docker_compose_v2:
+        project_src: "{{ vm_compose_dir }}"
+        build: always
+        files: compose.yaml
+        state: present
+  rescue:
+    - name: Log the error
+      ansible.builtin.debug:
+        msg: "{{ ansible_failed_result }}"
+    - name: Fail the role if the Kepler installation fails
+      ansible.builtin.fail:
+        msg: "The Kepler installation failed on VM. Please check the output above for more information."
+

--- a/ansible/roles/kepler_compose/vars/main.yml
+++ b/ansible/roles/kepler_compose/vars/main.yml
@@ -1,0 +1,6 @@
+---
+# This file contains variables that are less likely to be overridden
+kepler_repo: https://github.com/sustainable-computing-io/kepler.git
+kepler_dir: /opt/kepler
+metal_compose_dir: /opt/kepler/manifests/compose/validation/metal
+vm_compose_dir: /opt/kepler/manifests/compose/validation/vm

--- a/ansible/roles/kvm_vm/tasks/main.yml
+++ b/ansible/roles/kvm_vm/tasks/main.yml
@@ -1,10 +1,17 @@
 ---
 - name: Install KVM and create VM
   block:
-    - name: Install libvirt packages
+    - name: Install libvirt packages (For Ubuntu)
       ansible.builtin.package:
-        name: "{{ packages }}"
+        name: "{{ common_packages + ubuntu_packages }}"
         state: present
+      when: ansible_distribution == "Ubuntu"
+    
+    - name: Install libvirt packages (For RHEL)
+      ansible.builtin.package:
+        name: "{{ common_packages + rhel_packages }}"
+        state: present
+      when: ansible_distribution == "RedHat"
 
     - name: pip install lxml
       ansible.builtin.pip:
@@ -41,8 +48,8 @@
       ansible.builtin.file:
         path: /var/lib/libvirt/images
         state: directory
-        owner: qemu
-        group: qemu
+        owner: root
+        group: root
         mode: '0755'
 
     - name: Check if CentOS Stream 9 image exists
@@ -125,6 +132,18 @@
     - name: Parse the VM IP address
       ansible.builtin.set_fact:
         vm_ip: "{{ domifaddr_output.stdout }}"
+
+    - name: Set the VM name
+      ansible.builtin.set_fact:
+        vm_name: "{{ vm_name }}"
+
+    - name: Set the VM user
+      ansible.builtin.set_fact:
+        vm_user: "{{ vm_user }}"
+
+    - name: Set the VM ssh key path
+      ansible.builtin.set_fact:
+        ssh_key_path: "{{ ssh_key_path }}"
 
     - name: Display the VM IP address
       ansible.builtin.debug:

--- a/ansible/roles/kvm_vm/vars/main.yml
+++ b/ansible/roles/kvm_vm/vars/main.yml
@@ -26,11 +26,19 @@ vm_user: root
 vm_password: ansible_password
 ssh_pub_key_path: /tmp/vm_ssh_key.pub
 cloud_init_config_path: /var/lib/libvirt/images/cloud_init_config.yml
-packages:
+common_packages:
   - qemu-kvm
   - cloud-init
   - tuned
   - python3-libvirt
+
+ubuntu_packages:
+  - libvirt-daemon-system
+  - libguestfs-tools
+  - virtinst
+  - qemu-utils
+
+rhel_packages:
   - libvirt
   - virt-install
   - qemu-img

--- a/ansible/roles/validator/README.md
+++ b/ansible/roles/validator/README.md
@@ -1,0 +1,30 @@
+Validator
+=========
+
+A brief description of the role goes here.
+
+Role Variables
+--------------
+
+- `default/main.yml`:
+  Default variables for this role.
+  - `log_level`: Log level for the validator. Default is `info`.
+  - `prometheus_url`: URL of the Prometheus server. Default is `http://localhost:9090`.
+  - `rate_interval`: Rate interval for the validator. Default is `20s`.
+  - `steps`: Steps for the validator. Default is `5s`.
+- `vars/main.yml`:
+  Variables defined in this file have higher precedence and are not intended to be overridden.
+  - `validator_dir`: Directory where the validator is located.
+  - `validator_yaml_path`: Path to the validator YAML file.
+
+Dependencies
+------------
+
+- VM should be created using the `kvm_vm` role.
+- Docker should be installed on the VM using the `setup_docker` role.
+- Kepler should be installed on the VM using the `install_kepler` role.
+
+License
+-------
+
+BSD

--- a/ansible/roles/validator/defaults/main.yml
+++ b/ansible/roles/validator/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# defaults file for validator
+log_level: info
+prometheus_url: http://localhost:9090
+rate_interval: 20s
+steps: 5s
+

--- a/ansible/roles/validator/handlers/main.yml
+++ b/ansible/roles/validator/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for validator

--- a/ansible/roles/validator/meta/main.yml
+++ b/ansible/roles/validator/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/validator/tasks/main.yml
+++ b/ansible/roles/validator/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Run validator
+  ansible.builtin.include_tasks: validate.yml
+
+- name: Capture Prometheus TSDB Snapshot
+  ansible.builtin.include_tasks: snapshot.yml

--- a/ansible/roles/validator/tasks/snapshot.yml
+++ b/ansible/roles/validator/tasks/snapshot.yml
@@ -1,0 +1,18 @@
+---
+- name: Capture Prometheus TSDB Snapshot
+  ansible.builtin.uri:
+    url: http://localhost:9090/api/v1/admin/tsdb/snapshot
+    method: POST
+    return_content: yes
+  register: prometheus_snapshot
+
+- name: Extract the snapshot name from Prometheus API response
+  ansible.builtin.set_fact:
+    snap_name: "{{ prometheus_snapshot.json.data.name }}"
+
+- name: Copy Prometheus TSDB Snapshot
+  ansible.builtin.shell: |
+    cd {{ metal_compose_dir }}
+    docker compose cp prometheus:{{ snapshot_dir }}/{{ snap_name }} {{ tmp_dir }}
+  environment:
+    VM_IP: "{{ vm_ip }}"

--- a/ansible/roles/validator/tasks/validate.yml
+++ b/ansible/roles/validator/tasks/validate.yml
@@ -1,0 +1,42 @@
+---
+- name: Create validator.yaml
+  ansible.builtin.copy:
+    dest: "{{ validator_yaml_path }}"
+    content: |
+      log_level: {{ log_level }}
+      remote:
+        host: {{ vm_name }}
+        username: {{ vm_user }}
+        pkey: {{ ssh_key_path }}
+      metal:
+        vm:
+          name: {{ vm_name }}
+      prometheus:
+        job:
+          metal: metal
+          vm: vm
+        url: {{ prometheus_url }}
+        rate_interval: {{ rate_interval }}
+        steps: {{ steps }}
+      validations_file: ./validations.yaml
+
+- name: Run validator and handle potiental errors
+  block:
+    - name: Run the validator
+      ansible.builtin.shell: |
+        cd {{ validator_dir }}
+        hatch run validator stress
+      register: validator_output
+
+    - name: Show validator output
+      ansible.builtin.debug:
+        msg: "{{ validator_output.stdout.splitlines() }}"
+
+  rescue:
+    - name: Show validator errors
+      ansible.builtin.debug:
+        msg: "{{ validator_output.stderr.splitlines() }}"
+
+    - name: Fail the role if the validator fails
+      ansible.builtin.fail:
+        msg: "The validator test failed. Please check the output above for more information."

--- a/ansible/roles/validator/vars/main.yml
+++ b/ansible/roles/validator/vars/main.yml
@@ -1,0 +1,7 @@
+---
+# This file contains variables that are less likely to be overridden
+validator_dir: /opt/kepler/e2e/tools/validator
+validator_yaml_path: /opt/kepler/e2e/tools/validator/validator.yaml
+metal_compose_dir: /opt/kepler/manifests/compose/validation/metal
+snapshot_dir: /prometheus/snapshots
+tmp_dir: /tmp/snapshot

--- a/ansible/validator_playbook.yml
+++ b/ansible/validator_playbook.yml
@@ -1,0 +1,30 @@
+---
+- name: Create VM
+  hosts: "localhost"
+  become: yes
+  roles:
+    - kvm_vm
+  any_errors_fatal: true
+
+- name: Setup Environment
+  hosts: "{{ target_host | default('servers') }}"
+  become: yes
+  vars:
+    vm_ip: "{{ hostvars['localhost']['vm_ip'] }}"
+    ansible_user: root
+  roles:
+    - docker
+    - kepler_compose
+  any_errors_fatal: true
+
+- name: Run validator
+  hosts: "localhost"
+  become: yes
+  vars:
+    vm_name: "{{ hostvars['localhost']['vm_name'] }}"
+    vm_user: "{{ hostvars['localhost']['vm_user'] }}"
+    vm_ip: "{{ hostvars['localhost']['vm_ip'] }}"
+    ssh_key_path: "{{ hostvars['localhost']['ssh_key_path'] }}"
+  roles:
+    - validator
+  any_errors_fatal: true


### PR DESCRIPTION
This PR adds support for deploying Kepler on both metal and VM using Docker compose, ensuring local and CI environments align for easier testing and development.

Key changes:
- OS choices: Ubuntu for metal
- Workflow update:
  - Updated `create_equinix_runner.yml` to accept os name as a input parameter with default value as `rhel_9`.
  - Updated `setup-action` to check detect the type of OS and install the required packages accordingly.
  - Added new workflow `validator_compose.yml` which will deploy Kepler using Docker compose and run the validator tests
- kvm_role:
  - Installs the required packages based on host OS
  - Sets `vm_name`, `vm_user`, `ssh_key_path` as facts for reuse.
- New roles:
  - `docker`: Installs Docker on metal and VM.
  - `kepler_compose`: Deploys Kepler using Docker compose.
  - `validator`: Runs the validator tests.
- New playbooks:
  - `validator_playbook.yml`: Responsible for VM creation, Docker installation, Kepler deployment, Validator execution.

**No existing playbooks/workflows have been modified.**