### PR TITLE
chore(ci): ensure workflow fails on errors

### DIFF
--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -21,7 +21,6 @@ jobs:
     name: "Install"
     needs: Create-runner
     runs-on: self-hosted
-    continue-on-error: true
     outputs:
       runner-name: ${{ runner.name }}
 
@@ -127,6 +126,7 @@ jobs:
   Cleanup:
     name: "Cleanup"
     needs: [Install]
+    if: ${{ always() }}
     uses: ./.github/workflows/clean_equinix_runner.yml
     secrets: inherit
     with:

--- a/.github/workflows/equinix_metal_model_server_action_flow.yml
+++ b/.github/workflows/equinix_metal_model_server_action_flow.yml
@@ -21,7 +21,6 @@ jobs:
     name: "Install"
     needs: Create-runner
     runs-on: self-hosted
-    continue-on-error: true
     outputs:
       runner-name: ${{ runner.name }}
 
@@ -98,6 +97,7 @@ jobs:
   Cleanup:
     name: "Cleanup"
     needs: [Install]
+    if: ${{ always() }}
     uses: ./.github/workflows/clean_equinix_runner.yml
     secrets: inherit
     with:


### PR DESCRIPTION
This commit updates the workflows to accurately reflect the status, especially in cases of errors. It ensures that workflow is marked as failed when any step encounters error. While still guaranteeing that the runner cleanup process is executed