### PR TITLE
fix(disable_daily_vals): Disable daily validations

### DIFF
--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -75,12 +75,12 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           mkdir -p docs/validation/${DATE_STR}
           export KEPLER_TAG=$(ls -d /tmp/validator-* |tail -1 | sed 's/.*validator-//g')
-          python -m pip install --upgrade pip
-          pip install tabulate
-          python util/generate_daily_validations.py \
-            --report-md-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.md \
-            --report-json-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.json \
-            --new-val-filepath /tmp/validator-${KEPLER_TAG}/${KEPLER_TAG}.json
+          # python -m pip install --upgrade pip
+          # pip install tabulate
+          # python util/generate_daily_validations.py \
+          #   --report-md-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.md \
+          #   --report-json-filepath docs/daily-validations/daily-validations-kepler-standalone/daily-report.json \
+          #   --new-val-filepath /tmp/validator-${KEPLER_TAG}/${KEPLER_TAG}.json
 
           # copy the report to the directory
           mv /tmp/validator-${KEPLER_TAG}/ docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-${TIME_STR}/

--- a/.github/workflows/equinix_metal_model_server_action_flow.yml
+++ b/.github/workflows/equinix_metal_model_server_action_flow.yml
@@ -67,12 +67,12 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           mkdir -p docs/validation/${DATE_STR}
           export KEPLER_TAG=$(ls -d /tmp/validator-* |tail -1 | sed 's/.*validator-//g')
-          python -m pip install --upgrade pip
-          pip install tabulate
-          python util/generate_daily_validations.py \
-            --report-md-filepath docs/daily-validations/daily-validations-model-server/daily-report.md \
-            --report-json-filepath docs/daily-validations/daily-validations-model-server/daily-report.json \
-            --new-val-filepath /tmp/validator-${KEPLER_TAG}/${KEPLER_TAG}.json
+          # python -m pip install --upgrade pip
+          # pip install tabulate
+          # python util/generate_daily_validations.py \
+          #   --report-md-filepath docs/daily-validations/daily-validations-model-server/daily-report.md \
+          #   --report-json-filepath docs/daily-validations/daily-validations-model-server/daily-report.json \
+          #   --new-val-filepath /tmp/validator-${KEPLER_TAG}/${KEPLER_TAG}.json
 
           # copy the report to the directory
           mv /tmp/validator-${KEPLER_TAG}/ docs/validation/${DATE_STR}/validator-${KEPLER_TAG}-${TIME_STR}-model-server

--- a/util/generate_daily_validations.py
+++ b/util/generate_daily_validations.py
@@ -12,8 +12,6 @@ ERROR_METRIC_LIST = [
     "package_absolute",
     "platform_dynamic",
     "package_dynamic",
-    "platform_idle",
-    "package_idle",
 ]
 
 


### PR DESCRIPTION
Disabled daily validations for validation workflows due to removal of idle metrics. daily validations were breaking the validation workflows because they expect idle metrics. Refractoring must be done in future PRs to remove idle metrics from the graph.