### PR TITLE
chore: use the latest model server image tag

### DIFF
--- a/.github/workflows/equinix_metal_e2e.yml
+++ b/.github/workflows/equinix_metal_e2e.yml
@@ -50,7 +50,7 @@ jobs:
           sudo ss -tuln | grep 9100 || true
           curl -s localhost:9100/metrics | grep collector || true
           echo "Install Kepler"
-          ansible-playbook -i inventory.yml -vvv kepler_playbook.yml -e "target_host=localhost"
+          ansible-playbook -i inventory.yml -vvv kepler_playbook.yml
           echo "Create ssh tunnel"
           ansible-playbook -i inventory.yml ssh_tunnel_playbook.yml
 

--- a/ansible/host_vars/my-vm.yml
+++ b/ansible/host_vars/my-vm.yml
@@ -8,7 +8,7 @@ model_server_enable: "false"
 model_server_url: "http://model-server:8100"
 node_total_init_url: "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/specpower-0.7.11/acpi/AbsPower/BPFOnly/SGDRegressorTrainer_0.zip"
 node_components_init_url: "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/ec2-0.7.11/rapl-sysfs/AbsPower/BPFOnly/SGDRegressorTrainer_0.zip"
-model_server_entrypoint: "python3.10 quay.io/sustainable_computing_io/kepler_model_server:v0.7.11-2"
+model_server_entrypoint: "python3.10 quay.io/sustainable_computing_io/kepler_model_server:latest"
 local_model_directory: "/tmp/trained-equinix-models/"
 vm_model_directory: "/tmp/models/trained-equinix-models"
 http_port: 8080

--- a/ansible/kepler_validator.yml
+++ b/ansible/kepler_validator.yml
@@ -21,11 +21,12 @@
         - stress-ng
 
     - name: Clone the Kepler repository
+      ignore_errors: true
       git:
         repo: "{{ validator_repo }}"
         dest: "/opt/kepler"
         version: main
-        force: yes
+        force: false
 
     - name: Create validator.yaml
       copy:

--- a/ansible/metrics_playbook.yml
+++ b/ansible/metrics_playbook.yml
@@ -5,13 +5,6 @@
     - redhat.rhel_system_roles.firewall
   become: true
 
-- name: Use metrics system role to configure Grafana
-  hosts: metrics_monitor
-  roles:
-    - redhat.rhel_system_roles.metrics
-    - redhat.rhel_system_roles.firewall
-  become: true
-
 - name: Use Prometheus role to configure Prometheus server
   hosts: localhost
   become: true

--- a/ansible/model_server_restart.yml
+++ b/ansible/model_server_restart.yml
@@ -23,10 +23,38 @@
         name: container-model-server
         state: restarted
 
+    - name: Sleep for 10 seconds to ensure estimator is fully up and download the models
+      ansible.builtin.wait_for:
+        timeout: 10
+
+    - name: Run podman logs estimator and print the output
+      ansible.builtin.shell: podman logs estimator
+      register: estimator_logs
+      failed_when: estimator_logs.rc != 0
+      changed_when: estimator_logs.rc != 0
+   
+    - name: Print Estimator Logs
+      ansible.builtin.debug:
+        msg: "{{ estimator_logs.stdout }}"
+
     - name: Restart Kepler service
       ansible.builtin.systemd:
         name: container-kepler
         state: restarted
-    
+
+    - name: Sleep for 10 seconds to ensure kepler is fully up
+      ansible.builtin.wait_for:
+        timeout: 10
+
+    - name: Run podman logs kepler and print the output
+      ansible.builtin.shell: podman logs kepler
+      register: kepler_logs
+      failed_when: kepler_logs.rc != 0
+      changed_when: kepler_logs.rc != 0
+
+    - name: Print Kepler Logs
+      ansible.builtin.debug:
+        msg: "{{ kepler_logs.stdout }}"
+
     - name: Include Validation for Kepler and Model Server
       include_tasks: tasks/validate_model_server.yml


### PR DESCRIPTION
This is the prometheus chart during training (9:52 to 10:04), using the upstream models, and validation that uses trained models (10:30 to 10:34). As observed, the trained models show good alignment between the VM and metal jobs

![image](https://github.com/user-attachments/assets/fa6c03c6-0350-41f6-a11d-9db28659c0ef)

The validation results are:
```
   "Run validations",
        "node-rapl - kepler-package",
        "  - node-rapl  :  sum( rate( node_rapl_package_joules_total[20s] ) )",
        "  - kepler-package  :  sum( rate( kepler_node_package_joules_total{ job=\"metal\", }[20s] ) )",
        "\t MSE : 4.42",
        "\t MAPE: 3.13 %",
        "\t MAE : 1.65",
        "",
        "platform - absolute",
        "  - metal  :  sum( rate( kepler_vm_platform_joules_total{ job=\"metal\", vm_id=~\".*my-vm\", }[20s] ) )",
        "  - vm  :  sum( rate( kepler_node_platform_joules_total{ job=\"vm\", }[20s] ) )",
        "\t MSE : 7574.30",
        "\t MAPE: 75.44 %",
        "\t MAE : 81.05",
        "",
        "package - absolute",
        "  - metal  :  sum( rate( kepler_vm_package_joules_total{ job=\"metal\", vm_id=~\".*my-vm\", }[20s] ) )",
        "  - vm  :  sum( rate( kepler_node_package_joules_total{ job=\"vm\", }[20s] ) )",
        "\t MSE : 168.17",
        "\t MAPE: 17.65 %",
        "\t MAE : 10.16",
        "",
        "core - absolute",
        "  - metal  :  sum( rate( kepler_vm_core_joules_total{ job=\"metal\", vm_id=~\".*my-vm\", }[20s] ) )",
        "  - vm  :  sum( rate( kepler_node_core_joules_total{ job=\"vm\", }[20s] ) )",
        "\t MSE : 167.35",
        "\t MAPE: 17.90 %",
        "\t MAE : 10.22",
        "",
        "platform - dynamic",
        "  - metal  :  rate( kepler_vm_platform_joules_total{ job=\"metal\", vm_id=~\".*my-vm\", mode=\"dynamic\", }[20s] )",
        "  - vm  :  rate( kepler_node_platform_joules_total{ job=\"vm\", mode=\"dynamic\", }[20s] )",
        "\t MSE : 7574.30",
        "\t MAPE: 75.44 %",
        "\t MAE : 81.05",
        "",
        "package - dynamic",
        "  - metal  :  rate( kepler_vm_package_joules_total{ job=\"metal\", vm_id=~\".*my-vm\", mode=\"dynamic\", }[20s] )",
        "  - vm  :  rate( kepler_node_package_joules_total{ job=\"vm\", mode=\"dynamic\", }[20s] )",
        "\t MSE : 168.17",
        "\t MAPE: 17.65 %",
        "\t MAE : 10.16",
        "",
        "core - dynamic",
        "  - metal  :  rate( kepler_vm_core_joules_total{ job=\"metal\", vm_id=~\".*my-vm\", mode=\"dynamic\", }[20s] )",
        "  - vm  :  rate( kepler_node_core_joules_total{ job=\"vm\", mode=\"dynamic\", }[20s] )",
        "\t MSE : 167.35",
        "\t MAPE: 17.90 %",
        "\t MAE : 10.22",
        "",
        "dram - dynamic",
        "  - metal  :  rate( kepler_vm_dram_joules_total{ job=\"metal\", vm_id=~\".*my-vm\", mode=\"dynamic\", }[20s] )",
        "  - vm  :  rate( kepler_node_dram_joules_total{ job=\"vm\", mode=\"dynamic\", }[20s] )",
        "\t MSE : 0.14",
        "\t MAPE: 10.32 %",
        "\t MAE : 0.20",
        "",
        "cpu-time - absolute",
        "  - metal  :  sum( rate( kepler_vm_bpf_cpu_time_ms_total{ vm_id=~\".*my-vm\", job=\"metal\" }[20s] ) )",
        "  - vm  :  sum( rate( kepler_process_bpf_cpu_time_ms_total{ job=\"vm\", }[20s] ) )",
        "\t MSE : 865642.45",
        "\t MAPE: 18.25 %",
        "\t MAE : 705.90",
        "",
```

