### PR TITLE
chore(model-server): Use hatch to deploy Model Server

### DIFF
--- a/ansible/host_vars/my-vm.yml
+++ b/ansible/host_vars/my-vm.yml
@@ -8,7 +8,7 @@ model_server_enable: "false"
 model_server_url: "http://model-server:8100"
 node_total_init_url: "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/specpower-0.7.11/acpi/AbsPower/BPFOnly/SGDRegressorTrainer_0.zip"
 node_components_init_url: "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/ec2-0.7.11/rapl-sysfs/AbsPower/BPFOnly/SGDRegressorTrainer_0.zip"
-model_server_entrypoint: "python3.10 quay.io/sustainable_computing_io/kepler_model_server:latest"
+model_server_image: "quay.io/sustainable_computing_io/kepler_model_server:v0.7.12"
 local_model_directory: "/tmp/trained-equinix-models/"
 vm_model_directory: "/tmp/models/trained-equinix-models"
 http_port: 8080

--- a/ansible/model_server_playbook.yml
+++ b/ansible/model_server_playbook.yml
@@ -77,8 +77,8 @@
           ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name estimator \
               --privileged --network=host --pid=host -e MODEL_SERVER_ENABLE="{{ model_server_enable }}" -e MODEL_SERVER_URL="{{ model_server_url }}" \
               -v /mnt:/mnt -v /tmp:/tmp -v /mnt/kepler-config:/etc/kepler \
-              --entrypoint {{ model_server_entrypoint }} \
-              -u src/kepler_model/estimate/estimator.py
+              {{ model_server_image }} \
+              estimator -l info
           ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
           ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
           Type=notify
@@ -107,8 +107,8 @@
               --privileged --network=host --pid=host -e MODEL_SERVER_ENABLE="{{ model_server_enable }}" -e MODEL_SERVER_URL="{{ model_server_url }}" \
               -v /mnt:/mnt -v /mnt/kepler-config:/etc/kepler \
               -p 8100:8100 \
-              --entrypoint {{ model_server_entrypoint }} \
-              -u src/kepler_model/server/model_server.py
+              {{ model_server_image }} \
+              model-server -l info
           ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
           ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
           Type=notify


### PR DESCRIPTION
Rather than use python3.10 which is a hard dependency, we should use model-server's pyproject.toml hatch commands (model-server and estimator) to deploy the Model Server services. Additionally, we should use stable version 0.7.12 which should contain the fix for the estimator.