### PR TITLE
chore(validate_model_defaults): Added Polynomial and Xgboost to default list of target models

### DIFF
--- a/.github/workflows/equinix_metal_e2e.yml
+++ b/.github/workflows/equinix_metal_e2e.yml
@@ -6,7 +6,7 @@ on:
       target_models:
         description: 'Comma Separated List of Models to Train. Format: model_type/feature_type/trainer_name'
         required: false
-        default: 'AbsPower/BPFOnly/SGDRegressorTrainer,AbsPower/BPFOnly/ExponentialRegressionTrainer,AbsPower/BPFOnly/LogarithmicRegressionTrainer'
+        default: 'AbsPower/BPFOnly/SGDRegressorTrainer,AbsPower/BPFOnly/ExponentialRegressionTrainer,AbsPower/BPFOnly/LogarithmicRegressionTrainer,AbsPower/BPFOnly/PolynomialRegressionTrainer,AbsPower/BPFOnly/XgboostFitTrainer'
       model_server_image:
         description: 'Model Server Image to use for validation'
         required: false


### PR DESCRIPTION
Added AbsPower/BPFOnly/PolynomialRegressionTrainer,AbsPower/BPFOnly/XgboostFitTrainer to the list of target models to validate. Note this will add an additional hour to the training and validation e2e workflow.