### PR TITLE
fix(upload-train-logs): Add correct destination filepath for log upload

### DIFF
--- a/.github/workflows/aws_metal_e2e.yml
+++ b/.github/workflows/aws_metal_e2e.yml
@@ -136,8 +136,9 @@ jobs:
           snap_name=$(curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot | jq -r '.data.name')
           tar -cvzf /tmp/prometheus-snapshot/snapshot.tar.gz -C /var/lib/prometheus/snapshots ${snap_name}
           ls -l /tmp/prometheus-snapshot
+          ls -l /tmp/trained-equinix-models
           mv /tmp/prometheus-snapshot ${GITHUB_WORKSPACE}/docs/train-validate-e2e-aws/${DATE_STR}/
-          mv /tmp/trained-equinix-models/train_logs.log docs/train-validate-e2e/${DATE_STR}
+          mv /tmp/trained-equinix-models/train_logs.log ${GITHUB_WORKSPACE}/docs/train-validate-e2e-aws/${DATE_STR}/
 
           cd ${GITHUB_WORKSPACE}
           git config user.email "dependabot[bot]@users.noreply.github.com"

--- a/.github/workflows/equinix_metal_e2e.yml
+++ b/.github/workflows/equinix_metal_e2e.yml
@@ -111,8 +111,9 @@ jobs:
           snap_name=$(curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot | jq -r '.data.name')
           tar -cvzf /tmp/prometheus-snapshot/snapshot.tar.gz -C /var/lib/prometheus/snapshots ${snap_name}
           ls -l /tmp/prometheus-snapshot
+          ls -l /tmp/trained-equinix-models
           mv /tmp/prometheus-snapshot ${GITHUB_WORKSPACE}/docs/train-validate-e2e/${DATE_STR}/
-          mv /tmp/trained-equinix-models/train_logs.log docs/train-validate-e2e/${DATE_STR}
+          mv /tmp/trained-equinix-models/train_logs.log ${GITHUB_WORKSPACE}/docs/train-validate-e2e/${DATE_STR}/
 
           cd ${GITHUB_WORKSPACE}
           git config user.email "dependabot[bot]@users.noreply.github.com"


### PR DESCRIPTION
Destination filepath was corrected to include github workspace filepath.