### PR TITLE
feat(ansible): add Kepler config file support

### DIFF
--- a/ansible/roles/kepler_systemd/defaults/main.yml
+++ b/ansible/roles/kepler_systemd/defaults/main.yml
@@ -1,1 +1,10 @@
 ---
+kepler_metal_config:
+  EXPOSE_VM_METRICS: "true"
+  EXCLUDE_SWAPPER_PROCESS: "true"
+  ENABLE_PROCESS_METRICS: "true"
+
+kepler_vm_config:
+  EXPOSE_ESTIMATED_IDLE_POWER_METRICS: "false"
+  EXCLUDE_SWAPPER_PROCESS: "true"
+  ENABLE_PROCESS_METRICS: "true"

--- a/ansible/roles/kepler_systemd/tasks/metal.yml
+++ b/ansible/roles/kepler_systemd/tasks/metal.yml
@@ -4,6 +4,19 @@
     name: podman
     state: present
 
+- name: Create config directory
+  ansible.builtin.file:
+    path: "{{ config_path }}"
+    state: directory
+    mode: 0755
+
+- name: Create Kepler config
+  ansible.builtin.copy:
+    dest: "{{ config_path }}/{{ item.key }}"
+    content: "{{ item.value | lower }}"
+    mode: 0644
+  loop: "{{ kepler_metal_config | dict2items }}"
+
 - name: Create Kepler systemd unit file
   ansible.builtin.copy:
     content: |
@@ -20,9 +33,8 @@
       TimeoutStopSec=70
       ExecStartPre=/bin/rm -f %t/%n.ctr-id
       ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name kepler \
-          --privileged --network=host --pid=host --rm -e EXPOSE_VM_METRICS="true" -e EXCLUDE_SWAPPER_PROCESS="true" -e \
-          ENABLE_PROCESS_METRICS="true" -e EXCLUDE_SWAPPER_PROCESS="true" -v /usr/src:/usr/src -v /sys/:/sys/ -v /proc:/proc -v /etc:/etc \
-          {{ kepler_image }} --config-dir=/etc
+          --privileged --network=host --pid=host --rm -v /usr/src:/usr/src -v /sys/:/sys/ -v /proc:/proc -v /etc:/etc \
+          {{ kepler_image }}
       ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
       ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
       Type=notify

--- a/ansible/roles/kepler_systemd/tasks/vm.yml
+++ b/ansible/roles/kepler_systemd/tasks/vm.yml
@@ -9,6 +9,19 @@
     name: stress-ng
     state: present
 
+- name: Create config directory
+  ansible.builtin.file:
+    path: "{{ config_path }}"
+    state: directory
+    mode: 0755
+
+- name: Create Kepler config
+  ansible.builtin.copy:
+    dest: "{{ config_path }}/{{ item.key }}"
+    content: "{{ item.value | lower }}"
+    mode: 0644
+  loop: "{{ kepler_vm_config | dict2items }}"
+
 - name: Create Kepler systemd unit file
   ansible.builtin.copy:
     content: |
@@ -25,9 +38,8 @@
       TimeoutStopSec=70
       ExecStartPre=/bin/rm -f %t/%n.ctr-id
       ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name kepler \
-          --privileged --network=host --pid=host --rm -e EXPOSE_ESTIMATED_IDLE_POWER_METRICS="false" -e EXCLUDE_SWAPPER_PROCESS="true" -e \
-          ENABLE_PROCESS_METRICS="true" -v /usr/src:/usr/src -v /sys/:/sys/ -v /proc:/proc -v /etc:/etc \
-          {{ kepler_image }} --config-dir=/etc
+          --privileged --network=host --pid=host --rm -v /usr/src:/usr/src -v /sys/:/sys/ -v /proc:/proc -v /etc:/etc \
+          {{ kepler_image }}
       ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
       ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
       Type=notify

--- a/ansible/roles/kepler_systemd/vars/main.yml
+++ b/ansible/roles/kepler_systemd/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 # This contains the variables that are less likely to be overridden
 kepler_image: quay.io/sustainable_computing_io/kepler:latest
+config_path: /etc/kepler/kepler.config


### PR DESCRIPTION
This commit introduces a dedicated configuration file for Kepler when
deployed using systemd. It ensures separate configs for VM and metal deployments,
enhancing modularity and maintainability.

Key changes:
- Kepler configs are now defined in a separate config file(`/etc/kepler/kepler.config/`)
  instead of as environment variables in the systemd service file.
- This approach simplifies systemd service management and ensures Kepler
  reads config from the default file location
