### PR TITLE
[fix]: try with kubeconfig with try best

### DIFF
--- a/.github/actions/setup_kepler/action.yml
+++ b/.github/actions/setup_kepler/action.yml
@@ -7,6 +7,12 @@ runs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: try best to get kube config
+        shell: bash
+        run: |
+          mkdir -p /tmp/kubeconfig/
+          cp -r ~/.kube/config /tmp/kubeconfig/config
+
       - name: use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.10
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,10 @@ jobs:
           name: kubeconfig-pr-${{ github.run_id }}
           path: /tmp/kubeconfig
           retention-days: 1
+      - name: clean up kubeconfig as in new instance the kubeconfig should download from artifact
+        shell: bash
+        run: |
+          rm -rf /tmp/kubeconfig
       ## using a reusable pipeline for validation without commit, as dummy cluster the values are allowed to be none.
       - name: Config kube
         uses: ./.github/actions/kube_config


### PR DESCRIPTION
I suppose fails as kubeconfig location issue happen for https://github.com/sustainable-computing-io/kepler-metal-ci/actions/runs/12125279560/job/33805564812, here is a PR for test and try to fix it.
add a clean up steps in PR CI, as kubeconfig should download but not keep on the disk.
add additional steps in config kube, which will try best to get kubeconfig file.