### PR TITLE
ci: remove cron schedule from workflows

### DIFF
--- a/.github/workflows/equinix_k8s_flow.yml
+++ b/.github/workflows/equinix_k8s_flow.yml
@@ -19,8 +19,6 @@ on:
         description: 'metro location'
         required: false
         default: 'da'
-  schedule:
-    - cron: '0 18 * * *'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/equinix_k8s_flow_churncheck.yml
+++ b/.github/workflows/equinix_k8s_flow_churncheck.yml
@@ -19,8 +19,6 @@ on:
         description: 'metro location'
         required: false
         default: 'da'
-  schedule:
-    - cron: '0 18 * * *'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/equinix_metal_flow.yml
+++ b/.github/workflows/equinix_metal_flow.yml
@@ -2,8 +2,6 @@ name: Validation with Standalone Kepler
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 16 * * *'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/equinix_metal_model_server_action_flow.yml
+++ b/.github/workflows/equinix_metal_model_server_action_flow.yml
@@ -2,8 +2,6 @@ name: Validation with Model Server
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 23 * * *'
 
 permissions:
   pull-requests: write

--- a/docs/design/assets/equinix_k8s_flow.uml
+++ b/docs/design/assets/equinix_k8s_flow.uml
@@ -3,7 +3,7 @@
 
 start
 
-:Trigger Workflow Dispatch and Schedule;
+:Trigger Workflow Dispatch;
 note right
   Inputs:
     - termination_time (default: '1')

--- a/docs/design/assets/equinix_k8s_flow_churncheck.uml
+++ b/docs/design/assets/equinix_k8s_flow_churncheck.uml
@@ -3,7 +3,7 @@
 
 start
 
-:Trigger Workflow Dispatch and Schedule;
+:Trigger Workflow Dispatch;
 note right
   Inputs:
     - termination_time (default: '1')

--- a/docs/design/assets/equinix_metal_flow.uml
+++ b/docs/design/assets/equinix_metal_flow.uml
@@ -3,7 +3,7 @@
 
 start
 
-:Trigger workflow_dispatch or schedule (cron: '0 16 * * *');
+:Trigger workflow_dispatch;
 note right
   Permissions: pull-requests, contents, repository-projects, packages: write
 end note

--- a/docs/design/assets/equinix_metal_flow_model_server.uml
+++ b/docs/design/assets/equinix_metal_flow_model_server.uml
@@ -3,7 +3,7 @@
 
 start
 
-:Trigger via workflow_dispatch or schedule (cron: '0 23 * * *');
+:Trigger via workflow_dispatch;
 note right
   Permissions:
     - pull-requests, contents, repository-projects, packages: write


### PR DESCRIPTION
This commit removes the schedule cron from the workflows as we don't want these workflows to be triggered on a schedule anymore.